### PR TITLE
- Modifications on how to open Obsidian notes to avoid UnicodeDecodeE…

### DIFF
--- a/pyomd/note.py
+++ b/pyomd/note.py
@@ -30,7 +30,7 @@ class Note:
         """
         self.path: Path = Path(path)
         try:
-            with open(self.path, "r") as f:
+            with open(self.path, "r", encoding="utf-8", newline='\n') as f:
                 self.content: str = f.read()
         except Exception as e:
             raise NoteCreationError(path=path, exception=e) from e
@@ -73,7 +73,7 @@ class Note:
         """
         if not is_regex:
             pattern = re.escape(pattern)
-        self.content = re.sub(pattern, replace, self.content)
+        self.content = re.sub(pattern, replace, self.content, flags=re.MULTILINE)
 
     def update_content(
         self,
@@ -130,7 +130,7 @@ class Note:
                 path to the note. If None, overwrites the current note content.
         """
         p = self.path if path is None else path
-        with open(p, "w") as f:
+        with open(p, "w", encoding="utf-8", newline='\n') as f:
             f.write(self.content)
 
     @staticmethod


### PR DESCRIPTION
- Modifications on how to open Obsidian notes to avoid UnicodeDecodeError and to recognize correctly the end of lines
- Regular expressions are searched an replaced with MULTILINE flag on (^ matches the beginning of each line)