### PR TITLE
Adds quotes around Obsidian internal links in frontmatter property va…

### DIFF
--- a/pyomd/metadata.py
+++ b/pyomd/metadata.py
@@ -327,6 +327,8 @@ class Frontmatter(Metadata):
         for k, v in self.metadata.items():
             if len(v) == 1:
                 metadata_repr += f"{k}: {self._quotifyLink(v[0])}\n"
+            elif len(v) == 0:
+                metadata_repr += f"{k}: \n"
             else:
                 metadata_repr += f'{k}: ['
                 for v1 in v:

--- a/pyomd/metadata.py
+++ b/pyomd/metadata.py
@@ -301,6 +301,20 @@ class Frontmatter(Metadata):
 
     REGEX = "(?s)(^---\n).*?(\n---\n)"
 
+    def _quotifyLink(self, value) -> str:
+        """ Add quotes around Obsidian internal links found in metadata
+            property values
+
+            Returns:
+                String: value in double quotes if value is an internal link; otherwise,
+                the original value
+        """
+        if value.startswith("[[") and value.endswith("]]"):
+            return f"\"{value}\""
+        else:
+            return value
+
+
     def to_string(self) -> str:
         """Render metadata as a string.
 
@@ -312,9 +326,12 @@ class Frontmatter(Metadata):
         metadata_repr = ""
         for k, v in self.metadata.items():
             if len(v) == 1:
-                metadata_repr += f"{k}: {v[0]}\n"
+                metadata_repr += f"{k}: {self._quotifyLink(v[0])}\n"
             else:
-                metadata_repr += f'{k}: [ {", ".join(v)} ]\n'
+                metadata_repr += f'{k}: ['
+                for v1 in v:
+                    metadata_repr += f'{self._quotifyLink(v1)}'
+                    metadata_repr += "]\n" if v1 is v[-1] else ', '
         out = "---\n" + metadata_repr + "---\n"
         return out
 


### PR DESCRIPTION
Hello:
Thanks for putting together this great package that will help me organize my notes in a way not possible inside Obsidian!

Obsidian allows internal links as property values. But the links must be enclosed in quotes. Obsidian includes the quotes automatically when the user provides an internal link in the metadata.

The python-frontmatter package, used as a dependency, strips out these necessary quotes. I believe it is considering the quotes to be a string delimiter rather than part of the string.

My code restores quotes around internal links in frontmatter meta data.